### PR TITLE
Replacing deislabs references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HAS_TILT := $(shell command -v tilt;)
 HAS_GHR := $(shell command -v ghr;)
 
 
-IMAGE_NAME      ?= deislabs/smi-metrics
+IMAGE_NAME      ?= servicemeshinterface/smi-metrics
 
 GIT_COMMIT      ?= $(shell git rev-parse --short HEAD)
 ifdef RELEASE_VERSION
@@ -78,7 +78,7 @@ ifndef GITHUB_TOKEN
 	@echo "Requires a GITHUB_TOKEN with edit permissions for releases."
 	@exit 1
 endif
-	ghr -u deislabs \
+	ghr -u servicemeshinterface \
 		${RELEASE_VERSION} \
 		tmp/smi-metrics-*
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,5 @@
 k8s_yaml(local("helm template chart --set adapter=linkerd --name dev"))
 watch_file('chart')
-docker_build('deislabs/smi-metrics', '.')
+docker_build('servicemeshinterface/smi-metrics', '.')
 
 k8s_resource('dev-smi-metrics', port_forwards=['8080:8080', '8081:8081'])

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  name: deislabs/smi-metrics:VERSION
+  name: servicemeshinterface/smi-metrics:VERSION
   pullPolicy: IfNotPresent
 
 config:

--- a/docs/istio.md
+++ b/docs/istio.md
@@ -30,6 +30,6 @@ The labels required by SMI Metrics on the above metrics are:
 
 The first four labels are not present in the default metrics installation of Istio. So, For SMI to work with Istio, SMI needs separate metrics with labels that it requires.
 
-The manifests that add these required metrics can be found [here](https://github.com/deislabs/smi-metrics/tree/master/chart/templates/crds.yaml)
+The manifests that add these required metrics can be found [here](https://github.com/servicemeshinterface/smi-metrics/tree/master/chart/templates/crds.yaml)
 
 To verify if the labels are added correctly, prometheus metrics can be checked to see if those metrics have the configured labels.


### PR DESCRIPTION
This PR replaces the deis-labs references, except the ones in go code.

Once https://github.com/servicemeshinterface/smi-sdk-go/pull/61 merges, the go imports, etc will be updated.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>