### PR TITLE
Fix --set for config.* values

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,10 +4,10 @@ image:
   name: servicemeshinterface/smi-metrics:VERSION
   pullPolicy: IfNotPresent
 
-config:
-  # log-level: info
-  # api-port: 8080
-  # admin-port: 8081
-  # tls-cert-file: /var/run/smi-metrics/tls.crt
-  # tls-private-key: /var/run/smi-metrics/tls.key
+# config:
+#   log-level: info
+#   api-port: 8080
+#   admin-port: 8081
+#   tls-cert-file: /var/run/smi-metrics/tls.crt
+#   tls-private-key: /var/run/smi-metrics/tls.key
 resources: {}


### PR DESCRIPTION
Because no value is defined for `config` in values.yaml, Helm does not
correctly infer it should be an object, leading to this warning when using
`--set config.log-level=debug` or any other parameter under `config`:

    coalesce.go:160: warning: skipped value for config: Not a table.

This change comments out the empty definition for `config` so Helm can
determine `config` should be an object and set nested fields under it.