### PR TITLE
Use certs that have Alternate SAN field

### DIFF
--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -1,6 +1,6 @@
 {{- $cn :=  list (include "smi-metrics.fullname" .) .Release.Namespace "svc" | join "." -}}
-{{- $ca := genSelfSignedCert $cn (list) (list $cn) 365 }}
-{{- $cert := genSignedCert $cn nil nil 365 $ca -}}
+{{- $ca := genSelfSignedCert $cn (list) (list $cn) 365 -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca -}}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:

--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -1,5 +1,5 @@
 {{- $cn :=  list (include "smi-metrics.fullname" .) .Release.Namespace "svc" | join "." -}}
-{{- $ca := genSelfSignedCert $cn (list) (list $cn) 365 }
+{{- $ca := genSelfSignedCert $cn (list) (list $cn) 365 }}
 {{- $cert := genSignedCert $cn nil nil 365 $ca -}}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService

--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -1,6 +1,5 @@
 {{- $cn :=  list (include "smi-metrics.fullname" .) .Release.Namespace "svc" | join "." -}}
-{{- $ca := genSelfSignedCert $cn (list) (list $cn) 365 -}}
-{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca -}}
+{{- $cert := genSelfSignedCert $cn nil (list $cn) 365 -}}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
@@ -14,7 +13,7 @@ spec:
   service:
     name: {{ include "smi-metrics.fullname" . }}
     namespace: {{ .Release.Namespace }}
-  caBundle: {{ b64enc $ca.Cert }}
+  caBundle: {{ b64enc $cert.Cert }}
   group: metrics.smi-spec.io
   version: v1alpha1
   insecureSkipTLSVerify: false

--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -1,5 +1,5 @@
 {{- $cn :=  list (include "smi-metrics.fullname" .) .Release.Namespace "svc" | join "." -}}
-{{- $ca := genCA $cn 365 -}}
+{{- $ca := genSelfSignedCert $cn (list) (list $cn) 365 }
 {{- $cert := genSignedCert $cn nil nil 365 $ca -}}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService


### PR DESCRIPTION
Fixes #76 

K8s 1.19 upgrades to go 1.15 which updates the cert codes
to expect certs not only with CN field but also Alternate SAN.

Helm's genCA fn does not add the AlternateSAN field, and hence
genSelfSignedCert has to be used.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
